### PR TITLE
Prevent multiple requests from filter/sorting changes

### DIFF
--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -92,6 +92,7 @@ export class DashboardComponent implements OnInit,AfterViewInit,OnDestroy {
 
     const mergedObservable = merge(sortObservable,filterObservable);
     mergedObservable
+    .pipe(debounceTime(50))
     .subscribe( () => {
       this.reload();
     });

--- a/src/app/dashboard/dashboard.component.ts
+++ b/src/app/dashboard/dashboard.component.ts
@@ -2,7 +2,7 @@ import { ScrollDispatcher } from '@angular/cdk/overlay';
 import { AfterViewInit, ChangeDetectorRef, Component, NgZone, OnDestroy, OnInit } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
 import { ActivatedRoute } from '@angular/router';
-import { BehaviorSubject, Subject, Subscription } from 'rxjs';
+import { BehaviorSubject, merge, Subject, Subscription } from 'rxjs';
 import { debounceTime, first, skip, takeUntil } from 'rxjs/operators';
 import { environment } from 'src/environments/environment';
 import { OauthService } from '../reddit/oauth.service';
@@ -84,13 +84,15 @@ export class DashboardComponent implements OnInit,AfterViewInit,OnDestroy {
       }
     });
 
-    this.sortService.sortMode$
-    .pipe(takeUntil(this.ngUnsubscribe), skip(1)).subscribe( () => {
-      this.reload();
-    });
+    const sortObservable = this.sortService.sortMode$
+    .pipe(takeUntil(this.ngUnsubscribe), skip(1));
 
-    this.sortService.filterMode$
-    .pipe(takeUntil(this.ngUnsubscribe), skip(1)).subscribe( () => {
+    const filterObservable = this.sortService.filterMode$
+    .pipe(takeUntil(this.ngUnsubscribe), skip(1));
+
+    const mergedObservable = merge(sortObservable,filterObservable);
+    mergedObservable
+    .subscribe( () => {
       this.reload();
     });
   }

--- a/src/app/reddit/reddit-feed.service.ts
+++ b/src/app/reddit/reddit-feed.service.ts
@@ -46,7 +46,7 @@ export class RedditFeedService {
       );
     }
     else {
-      ref = this.httpClient.jsonp(`https://reddit.com/${subreddit?"r/"+subreddit+"/":""}.json?limit=${limit}${after?"&after="+after:""}`,"jsonp")
+      ref = this.httpClient.jsonp(`https://reddit.com/${subreddit?"r/"+subreddit+"/":""}${sortMode?sortMode+"/":""}.json?limit=${limit}${after?"&after="+after:""}${filterMode?"&t="+filterMode:""}`, "jsonp")
       .pipe(
         mergeMap( (x:any) => {return x.data.children;}),
         map(dataToPost)


### PR DESCRIPTION
Debounces changes to filtering/sorting merged subscriber by 50ms
As a result, switching from "Best" or another mode to "Top All," etc. will only send one request.
This fixes #4 